### PR TITLE
Respect initial request query parameters

### DIFF
--- a/SampleApp/Sources/democlient/rest/OAuthSignedRestClient.cs
+++ b/SampleApp/Sources/democlient/rest/OAuthSignedRestClient.cs
@@ -52,8 +52,14 @@ namespace SampleApp.Sources.democlient.rest
             var consumerRequest = new ConsumerRequest(oAuthContext, oAuthConsumerContext, accessToken)
                 .WithAcceptHeader(request.Accept)
                 .WithRawContentType(request.ContentType);
-            if(!request.IncludeHateoasLinks)
-                consumerRequest = consumerRequest.WithQueryParameters(new Dictionary<string, string>{{"ShowLinks", "none"}});
+
+            Dictionary<String, String> queryParams = request.QueryParameters ?? new Dictionary<String, String>();
+            if (!request.IncludeHateoasLinks)
+            {
+                queryParams.Add("ShowLinks", "none");
+            }
+
+            consumerRequest = consumerRequest.WithQueryParameters(queryParams);
 
             return consumerRequest.SignWithToken(accessToken);
         }


### PR DESCRIPTION
Useful for adding support for "embed": "boundaries" on field requests.